### PR TITLE
output-access-keys

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,3 +24,11 @@ output "endpoints" {
   }
   description = "Endpoint information of the storage account"
 }
+
+output "access_keys" {
+  value       = {
+    primary = azurerm_storage_account.this.primary_access_key
+    secondary = azurerm_storage_account.this.secondary_access_key
+  }
+  sensitive = true
+}


### PR DESCRIPTION
**:bulb: Summary of the pull request**
The Storage Account module needs to output the primary and secondary access keys
