### PR TITLE
fix: null access_tier on FileStorage shares so Azure stops rejecting them

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,9 +170,14 @@ resource "azurerm_storage_share" "this" {
 
   name               = each.key
   storage_account_id = azurerm_storage_account.this.id
-  access_tier        = each.value.enabled_protocol != "NFS" ? each.value.access_tier : null
-  enabled_protocol   = each.value.enabled_protocol
-  quota              = each.value.quota
+  # access_tier must be null for NFS shares AND for any share on a FileStorage
+  # account; Azure rejects any non-null value in either case with 400
+  # AccessTierNotSupported. The variable still defaults to "Hot" so consumers
+  # don't need to know which combinations require null — the module nulls it
+  # transparently where Azure mandates it.
+  access_tier      = (each.value.enabled_protocol == "NFS" || var.account_kind == "FileStorage") ? null : each.value.access_tier
+  enabled_protocol = each.value.enabled_protocol
+  quota            = each.value.quota
 
   lifecycle {
     precondition {


### PR DESCRIPTION
## Summary

Azure rejects any non-null `share.accessTier` on FileStorage accounts regardless of share protocol:

```
Error: AccessTierNotSupported: AccessTier is not supported for FileStorage account kind
```

The existing conditional in `main.tf:173` only nulled `access_tier` for NFS shares — SMB shares on a FileStorage Premium account still fail. This is a supported Azure combination (Premium FileStorage hosts both NFS and SMB shares on the same account), and the module already enables it via `provisioned_billing_model_version = "V2"`.

## Change

One-line extension to the existing conditional (`main.tf:173`):

```diff
-  access_tier        = each.value.enabled_protocol != "NFS" ? each.value.access_tier : null
+  access_tier        = (each.value.enabled_protocol == "NFS" || var.account_kind == "FileStorage") ? null : each.value.access_tier
```

The variable default stays `"Hot"`; callers don't need to change their `storage_file_shares` input to use FileStorage — the module silently nulls `access_tier` in the cases where Azure mandates it.

## Backwards compatibility

Fully backwards-compatible. Callers that today set `access_tier = "Hot"` (or any value) on a FileStorage share would previously fail at apply time with the Azure 400. After this change those calls succeed with `access_tier = null`, which is the only value Azure accepts on FileStorage anyway.

## Implicit regression coverage

`examples/provisioned-v2/main.tf` already exercises this case: it creates a FileStorage Premium account with `access_tier = "Premium"` on the share. That example currently fails real-Azure-apply with the AccessTierNotSupported error; after this fix the apply completes with the share's `access_tier` rendered as `null`.

## Test plan

- [x] `terraform fmt -recursive -check`
- [x] `terraform validate` at the root module
- [x] `terraform init` + `terraform validate` in `examples/provisioned-v2`
- [x] Real `terraform apply` against a sandbox subscription, verifying FileStorage Premium SA + NFS share + SMB share applies cleanly